### PR TITLE
add german translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ height="100">](https://f-droid.org/en/packages/com.darkempire78.opencalculator)
 
 ## 🇺🇸 Translation
 
-Available in : 🇺🇸, 🇫🇷, 🇮🇹, 🇹🇷, 🇦🇪, 🇦🇿, 🇷🇺, 🇬🇷
+Available in : 🇺🇸, 🇫🇷, 🇮🇹, 🇹🇷, 🇦🇪, 🇦🇿, 🇷🇺, 🇬🇷, 🇩🇪
 
 ## :camera: Screenshots
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -6,6 +6,5 @@
     <!-- App Menu -->
     <string name="app_menu_theme">Aussehen</string>
     <string name="app_menu_vibration">Vibration</string>
-    <string name="app_menu_about">Über</string>
-    <string name="point">,</string>
+    <string name="app_menu_about">Über</string>a
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,11 @@
+<resources>
+    <string name="app_name_display">Rechner</string>
+
+    <string name="select_theme_title">Wähle Aussehen</string>
+
+    <!-- App Menu -->
+    <string name="app_menu_theme">Aussehen</string>
+    <string name="app_menu_vibration">Vibration</string>
+    <string name="app_menu_about">Über</string>
+    <string name="point">,</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name" translatable="false">OpenCalc</string>
     <string name="app_name_display">Calculator</string>
 
@@ -19,7 +19,7 @@
     <string name="parentheses" translatable="false">(  )</string>
     <string name="add" translatable="false">+</string>
     <string name="substract" translatable="false">-</string>
-    <string name="point" translatable="false">.</string>
+    <string name="point" tools:ignore="MissingTranslation">.</string>
     <string name="equals" translatable="false">=</string>
     <string name="devide" translatable="false">÷</string>
     <string name="multiply" translatable="false">×</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="parentheses" translatable="false">(  )</string>
     <string name="add" translatable="false">+</string>
     <string name="substract" translatable="false">-</string>
-    <string name="point" tools:ignore="MissingTranslation">.</string>
+    <string name="point" translatable="false">.</string>
     <string name="equals" translatable="false">=</string>
     <string name="devide" translatable="false">÷</string>
     <string name="multiply" translatable="false">×</string>


### PR DESCRIPTION
This PR adds a german translation to OpenCalc.

Note that in german, a comma is used as a decimal point and `.` would be a thousand separation character if spaces were not used for that.

This PR does not provide translations to the theme selection menu.