### PR TITLE
fix about & rm unused dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,17 +32,16 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.8.0'
     implementation 'androidx.appcompat:appcompat:1.5.0'
     implementation 'androidx.preference:preference-ktx:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation("org.mariuszgromada.math:MathParser.org-mXparser:5.0.6")
     implementation 'com.google.android.material:material:1.6.1'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.1'
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
     implementation 'com.github.hannesa2:AndroidSlidingUpPanel:4.4.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    implementation 'com.google.code.gson:gson:2.9.0'
+    implementation 'com.google.code.gson:gson:2.9.1'
 }

--- a/app/src/main/java/com/darkempire78/opencalculator/AboutActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/AboutActivity.kt
@@ -62,7 +62,6 @@ class AboutActivity : AppCompatActivity() {
 
         // check the current selected theme
         Themes(this).checkTheme()
-        setContentView(R.layout.activity_about)
 
         // Set app version
         val versionName =  "v" + this.packageManager.getPackageInfo(this.packageName, PackageManager.GET_ACTIVITIES).versionName


### PR DESCRIPTION
Forgot a line with the old setContentView sorry!

Also those few less dependencies should make the app a bit smaller
So `androidx.navigation:navigation-fragment-ktx` is apparently not needed, but then I've got an error about conflicting versions of `androidx.lifecycle:lifecycle-viewmodel-ktx` when I remove it, so I've added the dependency directly. Weird... If you know a better way please do!