### PR TITLE
Restore "Material You" theme for system style where supported

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/Themes.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/Themes.kt
@@ -16,18 +16,18 @@ class Themes(private val context: Context) {
         const val AMOLED_THEME_INDEX = 1
         private const val MATERIAL_YOU_THEME_INDEX = 2
 
-        // Styles - Combinations of theme + day/night mode
-        private const val SYSTEM_STYLE_INDEX = 0
-        private const val LIGHT_STYLE_INDEX = 1
-        private const val DARK_STYLE_INDEX = 2
-        private const val AMOLED_STYLE_INDEX = 3
-        private const val MATERIAL_YOU_STYLE_INDEX = 4
-
+        // used to go from Preference int value to actual theme
         private val themeMap = mapOf(
             DEFAULT_THEME_INDEX to R.style.AppTheme,
             AMOLED_THEME_INDEX to R.style.AmoledTheme,
             MATERIAL_YOU_THEME_INDEX to R.style.MaterialYouTheme
         )
+
+        // Styles - Combinations of theme + day/night mode
+        private const val SYSTEM_STYLE_INDEX = 0
+        private const val LIGHT_STYLE_INDEX = 1
+        private const val DARK_STYLE_INDEX = 2
+        private const val AMOLED_STYLE_INDEX = 3
 
         fun openDialogThemeSelector(context: Context) {
 
@@ -62,24 +62,21 @@ class Themes(private val context: Context) {
 
             builder.setSingleChoiceItems(styles.values.toTypedArray(), checkedItem) { dialog, which ->
                 when (which) {
-                    0 -> {
+                    SYSTEM_STYLE_INDEX -> {
+                        // system style uses the Material You theme if supported
                         preferences.theme = if (DynamicColors.isDynamicColorAvailable()) MATERIAL_YOU_THEME_INDEX else DEFAULT_THEME_INDEX
                         preferences.forceDayNight = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
                     }
-                    1 -> {
+                    LIGHT_STYLE_INDEX -> {
                         preferences.theme = DEFAULT_THEME_INDEX
                         preferences.forceDayNight = AppCompatDelegate.MODE_NIGHT_NO
                     }
-                    2 -> {
+                    DARK_STYLE_INDEX -> {
                         preferences.theme = DEFAULT_THEME_INDEX
                         preferences.forceDayNight = AppCompatDelegate.MODE_NIGHT_YES
                     }
-                    3 -> {
+                    AMOLED_STYLE_INDEX -> {
                         preferences.theme = AMOLED_THEME_INDEX
-                    }
-                    4 -> {
-                        preferences.theme = MATERIAL_YOU_THEME_INDEX
-                        preferences.forceDayNight = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
                     }
                 }
                 dialog.dismiss()

--- a/app/src/main/java/com/darkempire78/opencalculator/Themes.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/Themes.kt
@@ -35,18 +35,22 @@ class Themes(private val context: Context) {
 
             val builder = MaterialAlertDialogBuilder(context)
 
+            val systemName =
+                if (DynamicColors.isDynamicColorAvailable())
+                    "${context.getString(R.string.theme_system)} (${context.getString(R.string.theme_material_you)})"
+                else
+                    context.getString(R.string.theme_system)
+
             val styles =  hashMapOf(
-                SYSTEM_STYLE_INDEX to context.getString(R.string.theme_system),
+                SYSTEM_STYLE_INDEX to systemName,
                 LIGHT_STYLE_INDEX to context.getString(R.string.theme_light),
                 DARK_STYLE_INDEX to context.getString(R.string.theme_dark),
                 AMOLED_STYLE_INDEX to context.getString(R.string.theme_amoled)
             )
-            if (DynamicColors.isDynamicColorAvailable())
-                styles[MATERIAL_YOU_STYLE_INDEX] = context.getString(R.string.theme_material_you)
 
             val checkedItem = when (preferences.theme) {
                 AMOLED_THEME_INDEX -> AMOLED_STYLE_INDEX
-                MATERIAL_YOU_THEME_INDEX -> MATERIAL_YOU_STYLE_INDEX
+                MATERIAL_YOU_THEME_INDEX -> SYSTEM_STYLE_INDEX
                 else -> {
                     when (preferences.forceDayNight) {
                         AppCompatDelegate.MODE_NIGHT_NO -> LIGHT_STYLE_INDEX
@@ -59,7 +63,7 @@ class Themes(private val context: Context) {
             builder.setSingleChoiceItems(styles.values.toTypedArray(), checkedItem) { dialog, which ->
                 when (which) {
                     0 -> {
-                        preferences.theme = DEFAULT_THEME_INDEX
+                        preferences.theme = if (DynamicColors.isDynamicColorAvailable()) MATERIAL_YOU_THEME_INDEX else DEFAULT_THEME_INDEX
                         preferences.forceDayNight = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
                     }
                     1 -> {


### PR DESCRIPTION
System style now uses Material You if the device supports it.

![image](https://user-images.githubusercontent.com/20557626/207151589-36aadd1d-786b-4fc8-bfcc-4b88d219badf.png)

Removed additional material you option that functions the same as System. 

This is why I assumed System was always the default app theme.