### PR TITLE
Fix typo

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/MainActivity.kt
@@ -355,7 +355,7 @@ class MainActivity : AppCompatActivity() {
         updateDisplay(view, decimalSeparator)
     }
 
-    fun devideButton(view: View) {
+    fun divideButton(view: View) {
         updateDisplay(view, "÷")
     }
 
@@ -427,7 +427,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    fun devideBy100(view: View) {
+    fun divideBy100(view: View) {
         updateDisplay(view, "%")
     }
 

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -54,7 +54,7 @@
                         android:layout_width="0dp"
                         android:layout_height="match_parent"
                         android:layout_weight="1"
-                        android:onClick="devideBy100"
+                        android:onClick="divideBy100"
                         android:text="@string/devideBy100" />
 
                     <Button
@@ -100,7 +100,7 @@
                         android:layout_height="match_parent"
                         android:layout_weight="1"
                         android:backgroundTint="?attr/button_symbol_color"
-                        android:onClick="devideButton"
+                        android:onClick="divideButton"
                         app:srcCompat="@drawable/divide" />
 
                     <Button

--- a/app/src/main/res/layout-sw720dp-land/activity_main.xml
+++ b/app/src/main/res/layout-sw720dp-land/activity_main.xml
@@ -123,7 +123,7 @@
                         android:layout_height="match_parent"
                         android:layout_margin="0dp"
                         android:layout_weight="1"
-                        android:onClick="devideBy100"
+                        android:onClick="divideBy100"
                         android:text="@string/devideBy100" />
 
                     <Button
@@ -314,7 +314,7 @@
                         android:layout_height="match_parent"
                         android:layout_weight="1"
                         android:backgroundTint="?attr/button_symbol_color"
-                        android:onClick="devideButton"
+                        android:onClick="divideButton"
                         app:srcCompat="@drawable/divide" />
                 </TableRow>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -124,7 +124,7 @@
                         android:layout_height="match_parent"
                         android:layout_margin="0dp"
                         android:layout_weight="1"
-                        android:onClick="devideBy100"
+                        android:onClick="divideBy100"
                         android:text="@string/devideBy100"
                         android:textSize="26sp" />
 
@@ -315,7 +315,7 @@
                         android:layout_height="match_parent"
                         android:layout_weight="1"
                         android:backgroundTint="?attr/button_symbol_color"
-                        android:onClick="devideButton"
+                        android:onClick="divideButton"
                         app:srcCompat="@drawable/divide" />
                 </TableRow>
 


### PR DESCRIPTION
While the term "devide" is technically correct, it has been obsoleted in favor of "divide".
Source: https://en.wiktionary.org/wiki/devide