### PR TITLE
Refactoring & crashfix when saving to history

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/MainActivity.kt
@@ -602,10 +602,12 @@ class MainActivity : AppCompatActivity() {
 
                     // Set cursor
                     withContext(Dispatchers.Main) {
+                        // Scroll to the end
+                        binding.input.setSelection(binding.input.length())
+
                         // Hide the cursor (do not remove this, it's not a duplicate)
                         binding.input.isCursorVisible = false
-                        // Scroll to the beginning
-                        binding.input.setSelection(0)
+
                         // Clear resultDisplay
                         binding.resultDisplay.setText("")
                     }


### PR DESCRIPTION
- Added a crashfix for when the history is empty
- Some refactoring so the UI (which is visible) gets updated before history (which is invisible)
- Some duplicate calls removed

Also, this PR fixes #171.