### PR TITLE
Fix #196

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/Expression.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/Expression.kt
@@ -55,6 +55,15 @@ class Expression {
         if (calculation[operatorBeforePercentPos] == '*') {
             return calculation
         }
+        
+        if(calculation[operatorBeforePercentPos] == '/') {
+            // insert brackets into percentage. Fixes 900/10% -> 900/(10/100), not 900/10/100 which evals differently.
+            // also prevents it from doing the rest of this function, which screws the calculation up
+            var stringFirst = calculation.substring(0, operatorBeforePercentPos+1)
+            var stringMiddle = calculation.substring(operatorBeforePercentPos+1, percentPos+1)
+            var stringLast = calculation.substring(percentPos+1, calculation.length)
+            return "$stringFirst($stringMiddle)$stringLast"
+        }
 
         // extract the first part of the calculation
         var calculationStringFirst = calculation.subSequence(0, operatorBeforePercentPos).toString()


### PR DESCRIPTION
Fixes #196 by preventing divide by percent calculations from being messed with, and adding brackets to fix order of operations

Before: 900/10% would be "cleaned" to (900)/(900)*(10)/100 -> 0.1

Now: 900/10% will be cleaned to 900/(10/100) -> 9000 (correct)