### PR TITLE
fix crash when recreating landscape main activity

### DIFF
--- a/app/src/androidTest/java/com/darkempire78/opencalculator/MainActivityTests.kt
+++ b/app/src/androidTest/java/com/darkempire78/opencalculator/MainActivityTests.kt
@@ -1,0 +1,36 @@
+package com.darkempire78.opencalculator
+
+import android.content.pm.ActivityInfo
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityTests {
+
+    @Test
+    fun testLandscapeMainActivity(){
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE)
+            }
+        }
+    }
+
+    @Test
+    fun testPortraitMainActivity(){
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
+            }
+        }
+    }
+
+    @Test
+    fun testRecreateMainActivity(){
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.recreate()
+        }
+    }
+}

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -93,7 +93,7 @@
                         android:onClick="keyDigitPadMappingToDisplay"
                         android:text="@string/nine" />
 
-                    <ImageButton
+                    <Button
                         android:id="@+id/divideButton"
                         style="@style/CalculatorButton.Small"
                         android:layout_width="0dp"
@@ -191,7 +191,7 @@
                         android:onClick="keyDigitPadMappingToDisplay"
                         android:text="@string/six" />
 
-                    <ImageButton
+                    <Button
                         android:id="@+id/multiplyButton"
                         style="@style/CalculatorButton.Small"
                         android:layout_width="0dp"
@@ -286,7 +286,7 @@
                         android:onClick="keyDigitPadMappingToDisplay"
                         android:text="@string/three"/>
 
-                    <ImageButton
+                    <Button
                         android:id="@+id/subtractButton"
                         style="@style/CalculatorButton.Small"
                         android:layout_width="0dp"
@@ -368,7 +368,7 @@
                         android:paddingEnd="5dp"
                         app:srcCompat="@drawable/backspace" />
 
-                    <ImageButton
+                    <Button
                         android:id="@+id/addButton"
                         style="@style/CalculatorButton.Small"
                         android:layout_width="0dp"
@@ -378,7 +378,7 @@
                         android:onClick="addButton"
                         app:srcCompat="@drawable/add" />
 
-                    <ImageButton
+                    <Button
                         android:id="@+id/equalsButton"
                         style="@style/CalculatorButton.Small"
                         android:layout_width="0dp"

--- a/app/src/main/res/layout-sw720dp-land/activity_main.xml
+++ b/app/src/main/res/layout-sw720dp-land/activity_main.xml
@@ -380,7 +380,7 @@
                         android:onClick="exponentButton"
                         app:srcCompat="@drawable/exponent" />
 
-                    <ImageButton
+                    <Button
                         android:id="@+id/divideButton"
                         style="@style/CalculatorButton.Small"
                         android:layout_width="0dp"
@@ -426,7 +426,7 @@
                         android:text="@string/nine"
                         android:textSize="@dimen/button_text_size"/>
 
-                    <ImageButton
+                    <Button
                         android:id="@+id/multiplyButton"
                         style="@style/CalculatorButton.Small"
                         android:layout_width="0dp"
@@ -473,7 +473,7 @@
                         android:text="@string/six"
                         android:textSize="@dimen/button_text_size"/>
 
-                    <ImageButton
+                    <android
                         android:id="@+id/subtractButton"
                         style="@style/CalculatorButton.Small"
                         android:layout_width="0dp"
@@ -519,7 +519,7 @@
                         android:text="@string/three"
                         android:textSize="@dimen/button_text_size"/>
 
-                    <ImageButton
+                    <android
                         android:id="@+id/addButton"
                         style="@style/CalculatorButton.Small"
                         android:layout_width="0dp"
@@ -566,7 +566,7 @@
                         app:srcCompat="@drawable/backspace_720dp"
                         tools:ignore="SpeakableTextPresentCheck" />
 
-                    <ImageButton
+                    <android
                         android:id="@+id/equalsButton"
                         style="@style/CalculatorButton.Small"
                         android:layout_width="0dp"


### PR DESCRIPTION
Fixes #303 

The `layout/activity_main.xml` uses `Button` while `layout-land/activity_main.xml` and `layout-sw720p-land` use `ImageButton` for some of the buttons.

This issue was described in [this Stack Overflow answer](https://stackoverflow.com/a/59785149/10871900).

This PR changes `layout-land/activity_main.xml` and `layout-sw720p-land` to use `Button` instead of `ImageButton`.

I wasn't able to test the changes to `layout-sw720p-land`.
