### PR TITLE
Implement BroadcastReceiver to start activity from TileService

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,12 @@
             </intent-filter>
         </service>
 
+        <receiver android:name=".MyTileReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="darkempire78.opencalculator.action.START_ACTIVITY" />
+            </intent-filter>
+        </receiver>
 
 </application>
 

--- a/app/src/main/java/com/darkempire78/opencalculator/MyTileReceiver.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/MyTileReceiver.kt
@@ -1,0 +1,13 @@
+package com.darkempire78.opencalculator
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class MyTileReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        val newIntent = Intent(context, MainActivity::class.java)
+        newIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context?.startActivity(newIntent)
+    }
+}

--- a/app/src/main/java/com/darkempire78/opencalculator/MyTileService.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/MyTileService.kt
@@ -1,22 +1,17 @@
 package com.darkempire78.opencalculator
 
 import android.content.Intent
-import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
-import android.graphics.drawable.Icon
-import android.os.Build
-import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
-import androidx.annotation.RequiresApi
 
-@RequiresApi(Build.VERSION_CODES.N)
 class MyTileService: TileService() {
+    companion object {
+        private const val BROADCAST_ACTION = "darkempire78.opencalculator.action.START_ACTIVITY"
+    }
 
     // Called when the user taps on your tile in an active or inactive state.
     override fun onClick() {
         super.onClick()
-        val intent = Intent(this, MainActivity::class.java)
-            .addFlags(FLAG_ACTIVITY_NEW_TASK)
-
-        startActivityAndCollapse(intent)
+        val intent = Intent(BROADCAST_ACTION)
+        sendBroadcast(intent)
     }
 }


### PR DESCRIPTION
Refactor: Use BroadcastReceiver for TileService activity launch

Switched to BroadcastReceiver approach for starting an activity from a TileService due to its compatibility with Android's security guidelines, ensuring a smooth and non-intrusive user experience. An alternative could be using notifications, but they may not prompt immediate action as effectively. 
