### PR TITLE
Issue #450

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/NumberFormatter.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/NumberFormatter.kt
@@ -7,7 +7,7 @@ object NumberFormatter {
         val numbersWithSeparators = addSeparators(numbersList, decimalSeparatorSymbol, groupingSeparatorSymbol)
         var textWithSeparators = textNoSeparator
         numbersList.forEachIndexed { index, number ->
-            textWithSeparators = textWithSeparators.replace(number, numbersWithSeparators[index])
+            textWithSeparators = textWithSeparators.replaceFirst(number, numbersWithSeparators[index])
         }
         return textWithSeparators
     }

--- a/app/src/test/java/com/darkempire78/opencalculator/NumberFormatterTest.kt
+++ b/app/src/test/java/com/darkempire78/opencalculator/NumberFormatterTest.kt
@@ -6,6 +6,20 @@ import org.junit.Test
 
 class NumberFormatterTest {
 
+    /** Issue #450: Four zeros after comma */
+    @Test
+    fun `given a decimal expression when formatting then format with grouping separator`() {
+        // Given
+        val expression = "5,000 + 5,00000"
+
+        // When
+        val result = formatter.format(expression, decimalSeparator, groupingSeparator)
+
+        // Then
+        val expected = "5,000 + 500,000"
+        assertEquals(expected, result)
+    }
+
     @Test
     fun `given a decimal number when formatting then format with grouping separator`() {
         // Given


### PR DESCRIPTION
### This pull request fixes issue #450 

**_Explaination:_**

- `text` to be formatted: "5,000 + 50,0000"
- `textNoSeparators`: "5000 + 500000"
- `extractedNumbers`: [5000,500000]
- `numbersWithSeparators`: ["5,000" , "500,000"]

the issue happens here: [during the loop of replacing the nubmers with the formatted numbers]
 `        numbersList.forEachIndexed { index, number ->`
`            textWithSeparators = textWithSeparators.replace(number, numbersWithSeparators[index])`
`        }`
in the first loop [index: 0, number: 5000]
`replace` will find two places for '5000' in the expression like this "[5000] + [5000]00"
so , `textWithSeparators` will be "[5,000] + [5,000]00"

using `replaceFirst` fixes the issue as it only replaces the first occurrence of the number