### PR TITLE
Automatically adjust input text size

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/MainActivity.kt
@@ -5,7 +5,9 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.ClipData
 import android.content.ClipboardManager
+import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import android.text.Editable
@@ -1118,25 +1120,98 @@ class MainActivity : AppCompatActivity() {
         val screenWidth = resources.displayMetrics.widthPixels
 
         // Text size will be reduced a bit before reaching the screen width, for a smoother experience
-        val maxWidth = screenWidth - 50
+        val maxWidth = screenWidth - dpToPx(20f, this)
 
-        val maxTextSize = 55f // TODO: This value should depend on the screen layout
-        val minTextSize = 30f
+        // Get the min and max text sizes for the input
+        val (minInputTextSize, maxInputTextSize) = getInputTextSizes(resources.configuration)
 
-        var textSize = maxTextSize
-        binding.input.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize)
+        var inputTextSize = maxInputTextSize
+        binding.input.setTextSize(TypedValue.COMPLEX_UNIT_SP, inputTextSize)
 
         val textBounds = android.graphics.Rect()
-        val text = binding.input.text.toString()
+        val inputText = binding.input.text.toString()
 
         // Measure the text size and adjust until it fits
         val paint = binding.input.paint
-        paint.getTextBounds(text, 0, text.length, textBounds)
+        paint.getTextBounds(inputText, 0, inputText.length, textBounds)
 
-        while (textBounds.width() > maxWidth && textSize > minTextSize) {
-            textSize -= 1f
-            binding.input.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize)
-            paint.getTextBounds(text, 0, text.length, textBounds)
+        // Reduce the text size until it fits
+        while (textBounds.width() > maxWidth && inputTextSize > minInputTextSize) {
+            inputTextSize -= 1f
+            binding.input.setTextSize(TypedValue.COMPLEX_UNIT_SP, inputTextSize)
+            paint.getTextBounds(inputText, 0, inputText.length, textBounds)
         }
     }
+
+    private fun getInputTextSizes(configuration: Configuration): Pair<Float, Float> {
+        val screenSize = configuration.screenLayout and Configuration.SCREENLAYOUT_SIZE_MASK
+        val orientation = configuration.orientation
+
+        var maxInputTextSize = 0f
+        var minInputTextSize = 0f
+
+        when (orientation) {
+            Configuration.ORIENTATION_PORTRAIT -> { // Portrait
+                when (screenSize) {
+                    Configuration.SCREENLAYOUT_SIZE_SMALL ->  {
+                        maxInputTextSize = 85f // TODO: Find the right values
+                        minInputTextSize = 35f // TODO: Find the right values
+                    }
+                    Configuration.SCREENLAYOUT_SIZE_NORMAL -> {
+                        maxInputTextSize = 85f
+                        minInputTextSize = 35f
+                    }
+                    Configuration.SCREENLAYOUT_SIZE_LARGE ->  {
+                        maxInputTextSize = 85f // TODO: Find the right values
+                        minInputTextSize = 35f // TODO: Find the right values
+                    }
+                    Configuration.SCREENLAYOUT_SIZE_XLARGE ->  {
+                        maxInputTextSize = 85f // TODO: Find the right values
+                        minInputTextSize = 35f // TODO: Find the right values
+                    }
+                    else ->  { // Set default values
+                        maxInputTextSize = 85f
+                        minInputTextSize = 35f
+                    }
+                }
+            }
+            Configuration.ORIENTATION_LANDSCAPE -> { // Landscape
+                when (screenSize) {
+                    Configuration.SCREENLAYOUT_SIZE_SMALL ->  {
+                        maxInputTextSize = 85f // TODO: Find the right values
+                        minInputTextSize = 35f // TODO: Find the right values
+                    }
+                    Configuration.SCREENLAYOUT_SIZE_NORMAL -> {
+                        maxInputTextSize = 45f
+                        minInputTextSize = 25f
+                    }
+                    Configuration.SCREENLAYOUT_SIZE_LARGE ->  {
+                        maxInputTextSize = 85f // TODO: Find the right values
+                        minInputTextSize = 35f // TODO: Find the right values
+                    }
+                    Configuration.SCREENLAYOUT_SIZE_XLARGE ->  {
+                        maxInputTextSize = 85f // TODO: Find the right values
+                        minInputTextSize = 35f // TODO: Find the right values
+                    }
+                    else ->  {
+                        maxInputTextSize = 45f
+                        minInputTextSize = 25f
+                    }
+                }
+            }
+            Configuration.ORIENTATION_UNDEFINED -> {
+                println("❌ Undefined orientation : screenSize -> $screenSize orientation -> $orientation")
+            }
+            else -> {
+                println("❌ Undefined orientation (else) : screenSize -> $screenSize orientation -> $orientation")
+            }
+        }
+
+        return Pair(minInputTextSize, maxInputTextSize)
+    }
+
+    private fun dpToPx(dp: Float, context: Context): Float {
+        return dp * context.resources.displayMetrics.density
+    }
+
 }

--- a/app/src/main/java/com/darkempire78/opencalculator/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/MainActivity.kt
@@ -10,6 +10,7 @@ import android.os.Build
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.TypedValue
 import android.view.HapticFeedbackConstants
 import android.view.MenuItem
 import android.view.View
@@ -220,6 +221,7 @@ class MainActivity : AppCompatActivity() {
 
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 updateResultDisplay()
+                adjustInputTextSize()
                 /*val afterTextLength = s?.length ?: 0
                 // If the afterTextLength is equals to 0 we have to clear resultDisplay
                 if (afterTextLength == 0) {
@@ -1110,5 +1112,31 @@ class MainActivity : AppCompatActivity() {
 
         // Disable the keyboard on display EditText
         binding.input.showSoftInputOnFocus = false
+    }
+
+    private fun adjustInputTextSize() {
+        val screenWidth = resources.displayMetrics.widthPixels
+
+        // Text size will be reduced a bit before reaching the screen width, for a smoother experience
+        val maxWidth = screenWidth - 50
+
+        val maxTextSize = 55f // TODO: This value should depend on the screen layout
+        val minTextSize = 30f
+
+        var textSize = maxTextSize
+        binding.input.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize)
+
+        val textBounds = android.graphics.Rect()
+        val text = binding.input.text.toString()
+
+        // Measure the text size and adjust until it fits
+        val paint = binding.input.paint
+        paint.getTextBounds(text, 0, text.length, textBounds)
+
+        while (textBounds.width() > maxWidth && textSize > minTextSize) {
+            textSize -= 1f
+            binding.input.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize)
+            paint.getTextBounds(text, 0, text.length, textBounds)
+        }
     }
 }

--- a/app/src/main/java/com/darkempire78/opencalculator/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/MainActivity.kt
@@ -1159,7 +1159,7 @@ class MainActivity : AppCompatActivity() {
                     }
                     Configuration.SCREENLAYOUT_SIZE_NORMAL -> {
                         maxInputTextSize = 85f
-                        minInputTextSize = 35f
+                        minInputTextSize = 40f
                     }
                     Configuration.SCREENLAYOUT_SIZE_LARGE ->  {
                         maxInputTextSize = 85f // TODO: Find the right values
@@ -1171,7 +1171,7 @@ class MainActivity : AppCompatActivity() {
                     }
                     else ->  { // Set default values
                         maxInputTextSize = 85f
-                        minInputTextSize = 35f
+                        minInputTextSize = 40f
                     }
                 }
             }


### PR DESCRIPTION
This pull request introduces a change that automatically adjusts the input text size to ensure that content fits optimally on the screen.

There is still some work to be done to support different layouts. For example, sw720dp-land should start with a text size of 95sp, not 55.

**Before**

[Screen_recording_20240627_195341.webm](https://github.com/Darkempire78/OpenCalc/assets/8866496/0753076e-e1a5-40f8-8f87-68d0e94851bf)

**After**

[Screen_recording_20240627_193449.webm](https://github.com/Darkempire78/OpenCalc/assets/8866496/864933f9-0366-49cd-9899-9803d5a9f76b)