### PR TITLE
Added feature for issue #470 - Add double/triple zero button

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
@@ -106,7 +106,7 @@ class MainActivity : AppCompatActivity() {
 
         // Long click to view popup options for double and triple zeroes
         binding.zeroButton.setOnLongClickListener {
-            showPopupMenu(binding.zeroButton, binding.input)
+            showPopupMenu(binding.zeroButton)
             true
         }
 
@@ -300,17 +300,17 @@ class MainActivity : AppCompatActivity() {
     }
 
     // Displays a popup menu with options to insert double zeros ("00") or triple zeros ("000") into the specified EditText when the zero button is long-pressed.
-    private fun showPopupMenu(zeroButton: Button, input: EditText) {
+    private fun showPopupMenu(zeroButton: Button) {
         val popupMenu = PopupMenu(this, zeroButton)
         popupMenu.menuInflater.inflate(R.menu.popup_menu_zero, popupMenu.menu)
         popupMenu.setOnMenuItemClickListener { menuItem: MenuItem ->
             when (menuItem.itemId) {
                 R.id.option_double_zero -> {
-                    input.append("00")
+                    updateDisplay(view, "00")
                     true
                 }
                 R.id.option_triple_zero -> {
-                    input.append("000")
+                    updateDisplay(view, "000")
                     true
                 }
                 else -> false

--- a/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
@@ -15,6 +15,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.accessibility.AccessibilityEvent
 import android.widget.Button
+import android.widget.EditText
 import android.widget.HorizontalScrollView
 import android.widget.Toast
 import androidx.activity.addCallback
@@ -100,6 +101,12 @@ class MainActivity : AppCompatActivity() {
             binding.input.setText("")
             binding.resultDisplay.text = ""
             isStillTheSameCalculation_autoSaveCalculationWithoutEqualOption = false
+            true
+        }
+
+        // Long click to view popup options for double and triple zeroes
+        binding.zeroButton.setOnLongClickListener {
+            showPopupMenu(binding.zeroButton, binding.input)
             true
         }
 
@@ -289,6 +296,27 @@ class MainActivity : AppCompatActivity() {
                 finish()
             }
         }
+
+    }
+
+    // Displays a popup menu with options to insert double zeros ("00") or triple zeros ("000") into the specified EditText when the zero button is long-pressed.
+    private fun showPopupMenu(zeroButton: Button, input: EditText) {
+        val popupMenu = PopupMenu(this, zeroButton)
+        popupMenu.menuInflater.inflate(R.menu.popup_menu_zero, popupMenu.menu)
+        popupMenu.setOnMenuItemClickListener { menuItem: MenuItem ->
+            when (menuItem.itemId) {
+                R.id.option_double_zero -> {
+                    input.append("00")
+                    true
+                }
+                R.id.option_triple_zero -> {
+                    input.append("000")
+                    true
+                }
+                else -> false
+            }
+        }
+        popupMenu.show()
 
     }
 

--- a/app/src/main/res/menu/popup_menu_zero.xml
+++ b/app/src/main/res/menu/popup_menu_zero.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/option_double_zero"
+        android:title="00" />
+    <item
+        android:id="@+id/option_triple_zero"
+        android:title="000" />
+</menu>


### PR DESCRIPTION
Added a pop-up menu with options to insert double zeros ("00") or triple zeros ("000") into the specified input when the zero button is long-pressed.

Here's the recording - 

https://github.com/user-attachments/assets/d5e6c6e0-c69c-4038-9630-be65fc0bd508

