### PR TITLE
Fix issue #508

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/calculator/Calculator.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/calculator/Calculator.kt
@@ -84,8 +84,8 @@ class Calculator(
         val intPart = parseFactor.toInt()
         val decimalPart = parseFactor.subtract(BigDecimal(intPart))
 
-        // if the number is null
-        if (value == BigDecimal.ZERO) {
+        // If value is 0 and the factor is 0, result is undefined
+        if (value == BigDecimal.ZERO && parseFactor == BigDecimal.ZERO) {
             syntax_error = true
             value = BigDecimal.ZERO
         } else {


### PR DESCRIPTION
`value` will never be null.  0^n is valid for all n other than n = 0.