### PR TITLE
fix incorrect theme name display for dark mode

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/Themes.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/Themes.kt
@@ -7,6 +7,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.startActivity
 import com.google.android.material.color.DynamicColors
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import android.content.res.Configuration
 
 class Themes(private val context: Context) {
 
@@ -115,7 +116,10 @@ class Themes(private val context: Context) {
         var theme = "THEME"
         when (themeID) {
             DEFAULT_THEME_INDEX -> {
-                theme = if (MyPreferences(this.context).forceDayNight == AppCompatDelegate.MODE_NIGHT_YES) {
+                val currentUiMode = context.resources.configuration.uiMode
+                val isNightMode = currentUiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
+
+                theme = if (MyPreferences(this.context).forceDayNight == AppCompatDelegate.MODE_NIGHT_YES || isNightMode) {
                     context.getString(R.string.theme_dark)
                 } else {
                     context.getString(R.string.theme_light)


### PR DESCRIPTION
Previously, when the system was set to dark mode, the application applied the dark theme correctly but displayed "Light" in the settings.
With this fix, the application now correctly shows "Dark" in the settings when the system theme is dark, ensuring consistency between the applied theme and the displayed theme name.

![Screenshot_20250516-193534](https://github.com/user-attachments/assets/0f1e19ed-6f72-440e-8560-5b918c4c0895)
![Screenshot_20250516-193515](https://github.com/user-attachments/assets/1e350678-3b22-48f5-99ae-2b9d7da5019a)

