### PR TITLE
Fix incorrect history order displaying

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
@@ -157,9 +157,9 @@ class MainActivity : AppCompatActivity() {
         historyAdapter.updateHistoryList()
         binding.historyRecylcleView.adapter = historyAdapter
 
-        // Scroll to the bottom of the recycle view
+        // Scroll to the top of the recycle view
         if (historyAdapter.itemCount > 0) {
-            binding.historyRecylcleView.scrollToPosition(historyAdapter.itemCount - 1)
+            binding.historyRecylcleView.scrollToPosition(0)
         }
 
         setSwipeTouchHelperForRecyclerView()
@@ -712,8 +712,8 @@ class MainActivity : AppCompatActivity() {
                                     }
                                     checkEmptyHistoryForNoHistoryLabel()
 
-                                    // Scroll to the bottom of the recycle view
-                                    binding.historyRecylcleView.scrollToPosition(historyAdapter.itemCount - 1)
+                                    // Scroll to the top of the recycle view
+                                    binding.historyRecylcleView.scrollToPosition(0)
                                 }
                             }
                         }
@@ -1097,8 +1097,8 @@ class MainActivity : AppCompatActivity() {
                                     historyAdapter.removeFirstHistoryElement()
                                 }
                                 checkEmptyHistoryForNoHistoryLabel()
-                                // Scroll to the bottom of the recycle view
-                                binding.historyRecylcleView.scrollToPosition(historyAdapter.itemCount - 1)
+                                // Scroll to the top of the recycle view
+                                binding.historyRecylcleView.scrollToPosition(0)
                             }
                         }
                     }

--- a/app/src/main/java/com/darkempire78/opencalculator/history/HistoryAdapter.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/history/HistoryAdapter.kt
@@ -42,16 +42,14 @@ class HistoryAdapter(
             )
         }
 
-        fun appendOneHistoryElement(history: History) {
-            this.history.add(history)
-            // Update the last 2 elements to avoid to have the same date and bar separator
-            if (this.history.size > 1) {
-                notifyItemInserted(this.history.size - 1)
-                notifyItemRangeChanged(this.history.size - 2, 2)
-            } else {
-                notifyItemInserted(this.history.size - 1)
-            }
+    fun appendOneHistoryElement(history: History) {
+        this.history.add(0, history)
+        notifyItemInserted(0)
+        // Update the first 2 elements to avoid to have the same date and bar separator
+        if (this.history.size > 1) {
+            notifyItemRangeChanged(0, 2)
         }
+    }
 
         fun removeHistoryElement(position: Int){
             // No idea why, but time.isNotEmpty() is not working, only time.isNullOrEmpty() works


### PR DESCRIPTION
The following changes implemented:

1. Reversing the order in how the history elements are added to the list.

2. Reversing the scroll order (backwards) of the recycle view.