### PR TITLE
Feature #384 calculation bookmarks

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/MyPreferences.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/MyPreferences.kt
@@ -175,20 +175,6 @@ class MyPreferences(context: Context) {
         return bookmark
     }
 
-    fun getBookmarkById(id: String): Bookmark? {
-        val bookmarks = getBookmarks()
-        return bookmarks.find { it.id == id }
-    }
-
-    fun updateBookmarkById(id: String, bookmark: Bookmark) {
-        val bookmarksList = getBookmarks()
-        val index = bookmarksList.indexOfFirst { it.id == id }
-        if (index != -1) {
-            bookmarksList[index] = bookmark
-            saveBookmarks(bookmarksList)
-        }
-    }
-
     fun removeBookmarkById(id: String) {
         val list = getBookmarks().filterNot { it.id == id }
         saveBookmarks(list)

--- a/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
@@ -32,6 +32,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.appcompat.app.AlertDialog
 import com.darkempire78.opencalculator.MyPreferences
 import com.darkempire78.opencalculator.R
 import com.darkempire78.opencalculator.TextSizeAdjuster
@@ -50,7 +51,6 @@ import com.darkempire78.opencalculator.databinding.ActivityMainBinding
 import com.darkempire78.opencalculator.dialogs.DonationDialog
 import com.darkempire78.opencalculator.history.History
 import com.darkempire78.opencalculator.history.HistoryAdapter
-import com.darkempire78.opencalculator.bookmarks.Bookmark
 import com.darkempire78.opencalculator.bookmarks.BookmarksAdapter
 import com.darkempire78.opencalculator.util.ScientificMode
 import com.darkempire78.opencalculator.util.ScientificModeTypes
@@ -494,6 +494,8 @@ class MainActivity : AppCompatActivity() {
                     bookmarksAdapter.removeAt(position)
                     // Persist removal
                     prefs.removeBookmarkById(removed.id)
+                    // Update bookmark icon in case the currently shown calculation is the one that is being deleted
+                    updateBookmarkIcon()
                 } else {
                     // Fallback: refresh from prefs
                     bookmarksAdapter.updateList(prefs.getBookmarks())
@@ -601,6 +603,23 @@ class MainActivity : AppCompatActivity() {
         // Clear drawer
         historyAdapter.clearHistory()
         checkEmptyHistoryForNoHistoryLabel()
+    }
+
+    fun clearBookmarks(menuItem: MenuItem) {
+        // Build alert modal for action confirmation
+        AlertDialog.Builder(this)
+            .setTitle(R.string.confirm_clear_bookmarks_title)
+            .setPositiveButton(R.string.confirm_clear_bookmarks_button) { _, _ ->
+                // Clear stored bookmarks
+                MyPreferences(this).saveBookmarks(emptyList())
+                // Refresh the adapter/UI
+                bookmarksAdapter.updateList(MyPreferences(this).getBookmarks())
+                Toast.makeText(this, R.string.bookmarks_cleared, Toast.LENGTH_SHORT).show()
+                // Also update the bookmark icon state in case the current calculation was bookmarked
+                updateBookmarkIcon()
+            }
+            .setNegativeButton(R.string.cancel_clear_bookmarks_button, null)
+            .show()
     }
 
     private fun keyVibration(view: View) {

--- a/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
@@ -209,29 +209,35 @@ class MainActivity : AppCompatActivity() {
         // --- END Bookmarks RecyclerView setup ---
 
         // --- History/Bookmarks tabs setup ---
-        binding.historyBookmarksTabs.addTab(binding.historyBookmarksTabs.newTab().setText(R.string.settings_category_history))
+        binding.historyBookmarksTabs.addTab(binding.historyBookmarksTabs.newTab().setText(R.string.history_tab_title))
         binding.historyBookmarksTabs.addTab(binding.historyBookmarksTabs.newTab().setText(R.string.bookmarks_tab_title))
 
         // Default to History tab
         showHistoryList()
         binding.slidingLayout.scrollableView = binding.historyRecylcleView
 
-        binding.historyBookmarksTabs.addOnTabSelectedListener(object : com.google.android.material.tabs.TabLayout.OnTabSelectedListener {
-            override fun onTabSelected(tab: com.google.android.material.tabs.TabLayout.Tab) {
-                when (tab.position) {
-                    0 -> { // History
-                        showHistoryList()
-                        binding.slidingLayout.scrollableView = binding.historyRecylcleView
+        binding.historyBookmarksTabs.addOnTabSelectedListener(
+            object : com.google.android.material.tabs.TabLayout.OnTabSelectedListener {
+                override fun onTabSelected(tab: com.google.android.material.tabs.TabLayout.Tab) {
+                    when (tab.position) {
+                        0 -> {
+                            showHistoryList()
+                            binding.slidingLayout.scrollableView = binding.historyRecylcleView
+                        }
+                        1 -> {
+                            showBookmarksList()
+                            binding.slidingLayout.scrollableView = binding.bookmarksRecyclerView
+                        }
                     }
-                    1 -> { // Bookmarks
-                        showBookmarksList()
-                        binding.slidingLayout.scrollableView = binding.bookmarksRecyclerView
-                    }
+                    // keep the grab handle above the list and refresh layout
+                    binding.slidingLayoutButton.bringToFront()
+                    binding.constraintLayout3.requestLayout()
+                    binding.slidingLayout.invalidate()
                 }
+                override fun onTabUnselected(tab: com.google.android.material.tabs.TabLayout.Tab) {}
+                override fun onTabReselected(tab: com.google.android.material.tabs.TabLayout.Tab) {}
             }
-            override fun onTabUnselected(tab: com.google.android.material.tabs.TabLayout.Tab) {}
-            override fun onTabReselected(tab: com.google.android.material.tabs.TabLayout.Tab) {}
-        })
+        )
         // --- END History/Bookmarks tabs setup ---
 
         // Set the sliding layout

--- a/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
@@ -208,6 +208,32 @@ class MainActivity : AppCompatActivity() {
         setSwipeTouchHelperForBookmarks()
         // --- END Bookmarks RecyclerView setup ---
 
+        // --- History/Bookmarks tabs setup ---
+        binding.historyBookmarksTabs.addTab(binding.historyBookmarksTabs.newTab().setText(R.string.settings_category_history))
+        binding.historyBookmarksTabs.addTab(binding.historyBookmarksTabs.newTab().setText(R.string.bookmarks_tab_title))
+
+        // Default to History tab
+        showHistoryList()
+        binding.slidingLayout.scrollableView = binding.historyRecylcleView
+
+        binding.historyBookmarksTabs.addOnTabSelectedListener(object : com.google.android.material.tabs.TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(tab: com.google.android.material.tabs.TabLayout.Tab) {
+                when (tab.position) {
+                    0 -> { // History
+                        showHistoryList()
+                        binding.slidingLayout.scrollableView = binding.historyRecylcleView
+                    }
+                    1 -> { // Bookmarks
+                        showBookmarksList()
+                        binding.slidingLayout.scrollableView = binding.bookmarksRecyclerView
+                    }
+                }
+            }
+            override fun onTabUnselected(tab: com.google.android.material.tabs.TabLayout.Tab) {}
+            override fun onTabReselected(tab: com.google.android.material.tabs.TabLayout.Tab) {}
+        })
+        // --- END History/Bookmarks tabs setup ---
+
         // Set the sliding layout
         binding.slidingLayout.addPanelSlideListener(object : PanelSlideListener {
             override fun onPanelSlide(panel: View, slideOffset: Float) {
@@ -483,6 +509,19 @@ class MainActivity : AppCompatActivity() {
             binding.bookmarksRecyclerView.scrollToPosition(bookmarksAdapter.itemCount - 1)
         }
         Toast.makeText(this, R.string.bookmarked, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun showHistoryList() {
+        binding.historyRecylcleView.visibility = View.VISIBLE
+        binding.noHistoryText.visibility =
+            if (historyAdapter.itemCount == 0) View.VISIBLE else View.GONE
+        binding.bookmarksRecyclerView.visibility = View.GONE
+    }
+
+    private fun showBookmarksList() {
+        binding.historyRecylcleView.visibility = View.GONE
+        binding.noHistoryText.visibility = View.GONE   // no “no bookmarks” label yet
+        binding.bookmarksRecyclerView.visibility = View.VISIBLE
     }
 
     fun openAppMenu(view: View) {

--- a/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
@@ -495,6 +495,8 @@ class MainActivity : AppCompatActivity() {
                     val removed = current[position]
                     // Update adapter first for snappy UI
                     bookmarksAdapter.removeAt(position)
+                    // Check if we removed the last bookmark to show the no bookmarks text
+                    checkEmptyBookmarksForNoBookmarksLabel()
                     // Persist removal
                     prefs.removeBookmarkById(removed.id)
                     // Update bookmark icon in case the currently shown calculation is the one that is being deleted
@@ -544,20 +546,22 @@ class MainActivity : AppCompatActivity() {
 
         // Update the icon to filled/outlined immediately to show if the calculation is bookmarked or not
         updateBookmarkIcon()
+        checkEmptyBookmarksForNoBookmarksLabel()
     }
 
     // --- History/Bookmarks tabs helpers ---
     private fun showHistoryList() {
         binding.historyRecylcleView.visibility = View.VISIBLE
-        binding.noHistoryText.visibility =
-            if (historyAdapter.itemCount == 0) View.VISIBLE else View.GONE
         binding.bookmarksRecyclerView.visibility = View.GONE
+        binding.noBookmarksText.visibility = View.GONE
+        checkEmptyHistoryForNoHistoryLabel()
     }
 
     private fun showBookmarksList() {
         binding.historyRecylcleView.visibility = View.GONE
-        binding.noHistoryText.visibility = View.GONE   // no “no bookmarks” label yet
+        binding.noHistoryText.visibility = View.GONE
         binding.bookmarksRecyclerView.visibility = View.VISIBLE
+        checkEmptyBookmarksForNoBookmarksLabel()
     }
     // --- END History/Bookmarks tabs helpers ---
 
@@ -620,6 +624,7 @@ class MainActivity : AppCompatActivity() {
                 Toast.makeText(this, R.string.bookmarks_cleared, Toast.LENGTH_SHORT).show()
                 // Also update the bookmark icon state in case the current calculation was bookmarked
                 updateBookmarkIcon()
+                checkEmptyBookmarksForNoBookmarksLabel()
             }
             .setNegativeButton(R.string.cancel_clear_bookmarks_button, null)
             .show()
@@ -1588,12 +1593,24 @@ class MainActivity : AppCompatActivity() {
     }
 
     fun checkEmptyHistoryForNoHistoryLabel() {
-        if (historyAdapter.itemCount==0) {
+        val isOnHistoryTab = binding.historyBookmarksTabs.selectedTabPosition == 0
+        if (isOnHistoryTab && historyAdapter.itemCount==0) {
             binding.historyRecylcleView.visibility = View.GONE
             binding.noHistoryText.visibility = View.VISIBLE
         }else {
             binding.noHistoryText.visibility = View.GONE
-            binding.historyRecylcleView.visibility = View.VISIBLE
+            if (isOnHistoryTab) binding.historyRecylcleView.visibility = View.VISIBLE
+        }
+    }
+
+    fun checkEmptyBookmarksForNoBookmarksLabel() {
+        val isOnBookmarksTab = binding.historyBookmarksTabs.selectedTabPosition == 1
+        if (isOnBookmarksTab && bookmarksAdapter.itemCount == 0) {
+            binding.bookmarksRecyclerView.visibility = View.GONE
+            binding.noBookmarksText.visibility = View.VISIBLE
+        } else {
+            binding.noBookmarksText.visibility = View.GONE
+            if (isOnBookmarksTab) binding.bookmarksRecyclerView.visibility = View.VISIBLE
         }
     }
 

--- a/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
@@ -127,6 +127,15 @@ class MainActivity : AppCompatActivity() {
 
         setContentView(view)
 
+        // --- Setup bookmark button ---
+        binding.bookmarkButton.setOnClickListener {
+            addBookmark()
+        }
+
+        // Show correct icon on first render
+        updateBookmarkIcon()
+        // --- END Setup bookmark button ---
+
         // Disable the keyboard on display EditText
         binding.input.showSoftInputOnFocus = false
 
@@ -496,7 +505,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     // Function to bookmark a calculation
-    fun addBookmark(menuItem: MenuItem) {
+    fun addBookmark() {
         val calculation = binding.input.text.toString()
         val shownResult = binding.resultDisplay.text.toString()
 
@@ -515,8 +524,10 @@ class MainActivity : AppCompatActivity() {
             binding.bookmarksRecyclerView.scrollToPosition(bookmarksAdapter.itemCount - 1)
         }
         Toast.makeText(this, R.string.bookmarked, Toast.LENGTH_SHORT).show()
+        updateBookmarkIcon()
     }
 
+    // --- History/Bookmarks tabs helpers ---
     private fun showHistoryList() {
         binding.historyRecylcleView.visibility = View.VISIBLE
         binding.noHistoryText.visibility =
@@ -529,6 +540,25 @@ class MainActivity : AppCompatActivity() {
         binding.noHistoryText.visibility = View.GONE   // no “no bookmarks” label yet
         binding.bookmarksRecyclerView.visibility = View.VISIBLE
     }
+    // --- END History/Bookmarks tabs helpers ---
+
+    // --- Bookmark helpers ---
+    private fun currentCalcAndResult(): Pair<String, String>? {
+        val calculation = binding.input.text.toString()
+        val shownResult = binding.resultDisplay.text.toString()
+        if (calculation.isEmpty() && shownResult.isEmpty()) return null
+        val result = if (shownResult.isNotEmpty()) shownResult else calculation
+        return calculation to result
+    }
+
+    private fun updateBookmarkIcon() {
+        val pair = currentCalcAndResult()
+        val isBookmarked = pair?.let { (calc, res) -> MyPreferences(this).isBookmarked(calc, res) } ?: false
+        val icon = if (isBookmarked) R.drawable.ic_bookmark_24 else R.drawable.ic_bookmark_border_24
+        binding.bookmarkButton.setImageResource(icon)
+        binding.bookmarkButton.isEnabled = pair != null
+    }
+    // --- END Bookmark helpers ---
 
     fun openAppMenu(view: View) {
         val popup = PopupMenu(this, view)
@@ -786,6 +816,7 @@ class MainActivity : AppCompatActivity() {
                         } else {
                             binding.resultDisplay.text = ""
                         }
+                        updateBookmarkIcon()
                     }
 
                     // Save to history if the option autoSaveCalculationWithoutEqualButton is enabled
@@ -864,12 +895,14 @@ class MainActivity : AppCompatActivity() {
                     } else {
                         withContext(Dispatchers.Main) {
                             binding.resultDisplay.text = ""
+                            updateBookmarkIcon()
                         }
                     }
                 }
             } else {
                 withContext(Dispatchers.Main) {
                     binding.resultDisplay.text = ""
+                    updateBookmarkIcon()
                 }
             }
         }
@@ -1129,6 +1162,7 @@ class MainActivity : AppCompatActivity() {
         binding.input.setText("")
         binding.resultDisplay.text = ""
         isStillTheSameCalculation_autoSaveCalculationWithoutEqualOption = false
+        updateBookmarkIcon()
     }
 
     @SuppressLint("SetTextI18n")
@@ -1272,6 +1306,7 @@ class MainActivity : AppCompatActivity() {
             } else {
                 withContext(Dispatchers.Main) { binding.resultDisplay.text = "" }
             }
+            updateBookmarkIcon()
         }
     }
 

--- a/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
@@ -253,7 +253,10 @@ class MainActivity : AppCompatActivity() {
         binding.slidingLayout.addPanelSlideListener(object : PanelSlideListener {
             override fun onPanelSlide(panel: View, slideOffset: Float) {
                 if (slideOffset == 0f) { // If the panel got collapsed
-                    binding.slidingLayout.scrollableView = binding.historyRecylcleView
+                    // Keep scrollableView in sync with the selected tab
+                    val isBookmarks = binding.historyBookmarksTabs.selectedTabPosition == 1
+                    binding.slidingLayout.scrollableView =
+                        if (isBookmarks) binding.bookmarksRecyclerView else binding.historyRecylcleView
                 }
             }
 

--- a/app/src/main/java/com/darkempire78/opencalculator/bookmarks/Bookmark.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/bookmarks/Bookmark.kt
@@ -1,0 +1,11 @@
+package com.darkempire78.opencalculator.bookmarks
+
+import com.google.gson.annotations.SerializedName
+import java.util.UUID
+
+data class Bookmark (
+    @SerializedName("calculation") var calculation: String,
+    @SerializedName("result") var result: String,
+    @SerializedName("time") var time: String = System.currentTimeMillis().toString(),
+    @SerializedName("id") var id: String = UUID.randomUUID().toString()
+)

--- a/app/src/main/java/com/darkempire78/opencalculator/bookmarks/BookmarksAdapter.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/bookmarks/BookmarksAdapter.kt
@@ -39,24 +39,9 @@ class BookmarksAdapter(
         notifyDataSetChanged()
     }
 
-    fun appendOne(b: Bookmark) {
-        items.add(b)
-        if (items.size > 1) {
-            notifyItemInserted(items.size - 1)
-            notifyItemRangeChanged(items.size - 2, 2)
-        } else {
-            notifyItemInserted(items.size - 1)
-        }
-    }
-
     fun removeAt(position: Int) {
         items.removeAt(position)
         notifyItemRemoved(position)
-    }
-
-    fun clear() {
-        items.clear()
-        notifyDataSetChanged()
     }
 
     inner class VH(itemView: View) : RecyclerView.ViewHolder(itemView) {

--- a/app/src/main/java/com/darkempire78/opencalculator/bookmarks/BookmarksAdapter.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/bookmarks/BookmarksAdapter.kt
@@ -1,0 +1,131 @@
+package com.darkempire78.opencalculator.bookmarks
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Context.CLIPBOARD_SERVICE
+import android.os.Build
+import android.text.format.DateUtils
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import android.widget.Toast
+import androidx.recyclerview.widget.RecyclerView
+import com.darkempire78.opencalculator.MyPreferences
+import com.darkempire78.opencalculator.R
+
+class BookmarksAdapter(
+    private var items: MutableList<Bookmark>,
+    private val onElementClick: (value: String) -> Unit,
+    private val context: Context
+) : RecyclerView.Adapter<BookmarksAdapter.VH>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
+        val view = LayoutInflater
+            .from(parent.context)
+            .inflate(R.layout.history_item, parent, false)
+        return VH(view)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: VH, position: Int) {
+        holder.bind(items[position], position)
+    }
+
+    fun updateList(newItems: MutableList<Bookmark>) {
+        items = newItems
+        notifyDataSetChanged()
+    }
+
+    fun appendOne(b: Bookmark) {
+        items.add(b)
+        if (items.size > 1) {
+            notifyItemInserted(items.size - 1)
+            notifyItemRangeChanged(items.size - 2, 2)
+        } else {
+            notifyItemInserted(items.size - 1)
+        }
+    }
+
+    fun removeAt(position: Int) {
+        items.removeAt(position)
+        notifyItemRemoved(position)
+    }
+
+    fun clear() {
+        items.clear()
+        notifyDataSetChanged()
+    }
+
+    inner class VH(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val calculation: TextView = itemView.findViewById(R.id.history_item_calculation)
+        private val result: TextView = itemView.findViewById(R.id.history_item_result)
+        private val time: TextView = itemView.findViewById(R.id.history_time)
+        private val separator: View = itemView.findViewById(R.id.history_separator)
+        private val sameDateSeparator: View = itemView.findViewById(R.id.history_same_date_separator)
+
+        private fun wrapInParenthesis(s: String): String {
+            return if (s.first() != '(' || s.last() != ')') "($s)" else s
+        }
+
+        fun bind(b: Bookmark, position: Int) {
+            calculation.text = b.calculation
+            result.text = b.result
+
+            if (b.time.isEmpty()) {
+                time.visibility = View.GONE
+            } else {
+                val rel = DateUtils.getRelativeTimeSpanString(
+                    b.time.toLong(),
+                    System.currentTimeMillis(),
+                    DateUtils.DAY_IN_MILLIS,
+                    DateUtils.FORMAT_ABBREV_RELATIVE
+                )
+                time.text = rel
+                // Keep same grouping to look like history for now:
+                if (position + 1 < items.size) {
+                    val nextRel = DateUtils.getRelativeTimeSpanString(
+                        items[position + 1].time.toLong(),
+                        System.currentTimeMillis(),
+                        DateUtils.DAY_IN_MILLIS,
+                        DateUtils.FORMAT_ABBREV_RELATIVE
+                    )
+                    if (nextRel == rel) {
+                        // Show only sameDateSeparator
+                        separator.visibility = View.GONE
+                        sameDateSeparator.visibility = View.VISIBLE
+                    } else {
+                        // Relative times don't match -> show only the main separator
+                        separator.visibility = View.VISIBLE
+                        sameDateSeparator.visibility = View.GONE
+                    }
+                } else {
+                    separator.visibility = View.VISIBLE
+                    sameDateSeparator.visibility = View.GONE
+                }
+            }
+
+            calculation.setOnClickListener { onElementClick.invoke(wrapInParenthesis(b.calculation)) }
+            result.setOnClickListener { onElementClick.invoke(wrapInParenthesis(b.result)) }
+
+            if (MyPreferences(itemView.context).longClickToCopyValue) {
+                calculation.setOnLongClickListener {
+                    val cm = itemView.context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+                    cm.setPrimaryClip(ClipData.newPlainText(itemView.context.getString(R.string.copied_history_calculation), b.calculation))
+                    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2)
+                        Toast.makeText(itemView.context, R.string.value_copied, Toast.LENGTH_SHORT).show()
+                    true
+                }
+                result.setOnLongClickListener {
+                    val cm = itemView.context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+                    cm.setPrimaryClip(ClipData.newPlainText(itemView.context.getString(R.string.copied_history_result), b.result))
+                    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2)
+                        Toast.makeText(itemView.context, R.string.value_copied, Toast.LENGTH_SHORT).show()
+                    true
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/darkempire78/opencalculator/bookmarks/BookmarksAdapter.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/bookmarks/BookmarksAdapter.kt
@@ -84,7 +84,26 @@ class BookmarksAdapter(
                     DateUtils.FORMAT_ABBREV_RELATIVE
                 )
                 time.text = rel
-                // Keep same grouping to look like history for now:
+
+                // Hide current time if previous element is same day
+                if (position > 0) {
+                    val prev = items[position - 1]
+                    val prevRel = DateUtils.getRelativeTimeSpanString(
+                        prev.time.toLong(),
+                        System.currentTimeMillis(),
+                        DateUtils.DAY_IN_MILLIS,
+                        DateUtils.FORMAT_ABBREV_RELATIVE
+                    )
+                    if (prevRel == rel) {
+                        time.visibility = View.GONE
+                    } else {
+                        time.visibility = View.VISIBLE
+                    }
+                } else {
+                    time.visibility = View.VISIBLE
+                }
+
+                // Hide main separator if next element is same day
                 if (position + 1 < items.size) {
                     val nextRel = DateUtils.getRelativeTimeSpanString(
                         items[position + 1].time.toLong(),

--- a/app/src/main/res/drawable/ic_bookmark_24.xml
+++ b/app/src/main/res/drawable/ic_bookmark_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M17,3H7c-1.1,0 -1.99,0.9 -1.99,2L5,21l7,-3 7,3V5c0,-1.1 -0.9,-2 -2,-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_bookmark_border_24.xml
+++ b/app/src/main/res/drawable/ic_bookmark_border_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M17,3L7,3c-1.1,0 -1.99,0.9 -1.99,2L5,21l7,-3 7,3L19,5c0,-1.1 -0.9,-2 -2,-2zM17,18l-5,-2.18L7,18L7,5h10v13z"/>
+</vector>

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -535,10 +535,10 @@
     <ImageButton
         android:id="@+id/bookmarkButton"
         style="@style/Widget.AppCompat.Button.Borderless"
-        android:layout_width="70dp"
+        android:layout_width="55dp"
         android:layout_height="0dp"
         android:paddingEnd="8dp"
-        android:paddingStart="14dp"
+        android:paddingStart="8dp"
         android:background="?attr/foreground_color"
         android:scaleType="fitCenter"
         android:contentDescription="@string/bookmark_border_icon_desc"

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -421,16 +421,26 @@
             tools:context=".activities.MainActivity"
             android:background="@drawable/display_background">
 
+            <com.google.android.material.tabs.TabLayout
+                    android:id="@+id/historyBookmarksTabs"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:tabIndicatorFullWidth="false"
+                    app:tabMode="fixed"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
+
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/history_recylcle_view"
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
                 android:layout_marginBottom="15dp"
                 android:background="?attr/history_background_color"
-                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/historyBookmarksTabs"
+                app:layout_constraintBottom_toTopOf="@+id/sliding_layout_button"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintBottom_toTopOf="@+id/sliding_layout_button"/>
+                app:layout_constraintEnd_toEndOf="parent"/>
 
             <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/bookmarksRecyclerView"
@@ -438,7 +448,7 @@
                     android:layout_height="0dp"
                     android:background="?attr/history_background_color"
                     android:visibility="gone"
-                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/historyBookmarksTabs"
                     app:layout_constraintBottom_toTopOf="@id/sliding_layout_button"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -456,10 +466,10 @@
                 android:gravity="center"
                 android:layout_marginBottom="32dp"
                 android:background="?attr/history_background_color"
+                app:layout_constraintTop_toBottomOf="@+id/historyBookmarksTabs"
                 app:layout_constraintBottom_toTopOf="@+id/sliding_layout_button"
-                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"/>
+                app:layout_constraintEnd_toEndOf="parent"/>
 
             <View
                 android:id="@+id/history_sliding_layout_button"

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -509,6 +509,22 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <ImageButton
+        android:id="@+id/bookmarkButton"
+        style="@style/Widget.AppCompat.Button.Borderless"
+        android:layout_width="70dp"
+        android:layout_height="0dp"
+        android:paddingEnd="8dp"
+        android:paddingStart="14dp"
+        android:background="?attr/foreground_color"
+        android:scaleType="fitCenter"
+        android:contentDescription="@string/bookmark_border_icon_desc"
+        app:tint="?attr/text_second_color"
+        app:srcCompat="@drawable/ic_bookmark_border_24"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/inputHorizontalScrollView"
+        app:layout_constraintBottom_toBottomOf="@+id/inputHorizontalScrollView" />
+
     <HorizontalScrollView
         android:id="@+id/inputHorizontalScrollView"
         android:layout_width="0dp"
@@ -516,10 +532,10 @@
         android:background="?attr/foreground_color"
         android:overScrollMode="never"
         android:scrollbars="none"
+        app:layout_constraintTop_toBottomOf="@+id/menuButton"
         app:layout_constraintBottom_toTopOf="@+id/guideline1"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/menuButton">
+        app:layout_constraintStart_toEndOf="@+id/bookmarkButton"
+        app:layout_constraintEnd_toEndOf="parent">
 
         <EditText
             android:id="@+id/input"
@@ -595,17 +611,6 @@
                 android:textColor="?attr/text_second_color"
                 android:textIsSelectable="true"
                 android:textSize="30sp" />
-
-            <ImageButton
-                android:id="@+id/bookmarkButton"
-                style="@style/Widget.AppCompat.Button.Borderless"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:paddingHorizontal="8dp"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@string/bookmark_border_icon_desc"
-                app:tint="?attr/text_second_color"
-                app:srcCompat="@drawable/ic_bookmark_border_24" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -17,6 +17,7 @@
         app:layout_constraintTop_toBottomOf="@+id/resultDisplayHorizontalScrollView"
         app:umanoPanelHeight="31dp"
         app:umanoShadowHeight="0dp"
+        app:umanoOverlay="true"
         tools:ignore="MissingConstraints">
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -32,7 +33,7 @@
                 android:layout_height="0dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                android:padding="8dp">
+                android:paddingTop="48dp">
 
                 <TableRow
                     android:layout_width="match_parent"
@@ -446,6 +447,7 @@
                     android:id="@+id/bookmarksRecyclerView"
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
+                    android:layout_marginBottom="15dp"
                     android:background="?attr/history_background_color"
                     android:visibility="gone"
                     app:layout_constraintTop_toBottomOf="@+id/historyBookmarksTabs"

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -473,12 +473,28 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"/>
 
+            <TextView
+                android:id="@+id/no_bookmarks_text"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:text="@string/no_bookmarks_available"
+                android:textSize="18sp"
+                android:textColor="?attr/text_color"
+                android:gravity="center"
+                android:layout_marginBottom="32dp"
+                android:background="?attr/history_background_color"
+                android:visibility="gone"
+                app:layout_constraintTop_toBottomOf="@+id/historyBookmarksTabs"
+                app:layout_constraintBottom_toTopOf="@+id/sliding_layout_button"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
             <androidx.constraintlayout.widget.Barrier
                 android:id="@+id/list_bottom_barrier"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 app:barrierDirection="bottom"
-                app:constraint_referenced_ids="history_recylcle_view,bookmarksRecyclerView,no_history_text" />
+                app:constraint_referenced_ids="history_recylcle_view,bookmarksRecyclerView,no_history_text,no_bookmarks_text" />
 
             <View
                 android:id="@+id/history_sliding_layout_button"

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -473,6 +473,13 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"/>
 
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/list_bottom_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="history_recylcle_view,bookmarksRecyclerView,no_history_text" />
+
             <View
                 android:id="@+id/history_sliding_layout_button"
                 android:layout_width="match_parent"
@@ -480,7 +487,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/history_recylcle_view"/>
+                app:layout_constraintTop_toBottomOf="@+id/list_bottom_barrier"/>
 
 
             <View

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -432,6 +432,19 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintBottom_toTopOf="@+id/sliding_layout_button"/>
 
+            <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/bookmarksRecyclerView"
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp"
+                    android:background="?attr/history_background_color"
+                    android:visibility="gone"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toTopOf="@id/sliding_layout_button"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    tools:visibility="visible"
+                    tools:listitem="@layout/history_item" />
+
             <TextView
                 android:id="@+id/no_history_text"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -596,6 +596,17 @@
                 android:textIsSelectable="true"
                 android:textSize="30sp" />
 
+            <ImageButton
+                android:id="@+id/bookmarkButton"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:paddingHorizontal="8dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/bookmark_border_icon_desc"
+                app:tint="?attr/text_second_color"
+                app:srcCompat="@drawable/ic_bookmark_border_24" />
+
         </LinearLayout>
 
     </HorizontalScrollView>

--- a/app/src/main/res/layout-sw720dp-land/activity_main.xml
+++ b/app/src/main/res/layout-sw720dp-land/activity_main.xml
@@ -691,12 +691,28 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"/>
 
+            <TextView
+                android:id="@+id/no_bookmarks_text"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:text="@string/no_bookmarks_available"
+                android:textSize="18sp"
+                android:textColor="?attr/text_color"
+                android:gravity="center"
+                android:layout_marginBottom="32dp"
+                android:background="?attr/history_background_color"
+                android:visibility="gone"
+                app:layout_constraintTop_toBottomOf="@+id/historyBookmarksTabs"
+                app:layout_constraintBottom_toTopOf="@+id/sliding_layout_button"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
             <androidx.constraintlayout.widget.Barrier
                 android:id="@+id/list_bottom_barrier"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 app:barrierDirection="bottom"
-                app:constraint_referenced_ids="history_recylcle_view,bookmarksRecyclerView,no_history_text" />
+                app:constraint_referenced_ids="history_recylcle_view,bookmarksRecyclerView,no_history_text,no_bookmarks_text" />
 
             <View
                 android:id="@+id/history_sliding_layout_button"

--- a/app/src/main/res/layout-sw720dp-land/activity_main.xml
+++ b/app/src/main/res/layout-sw720dp-land/activity_main.xml
@@ -19,6 +19,22 @@
         app:layout_constraintStart_toStartOf="@+id/menuButton"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <ImageButton
+        android:id="@+id/bookmarkButton"
+        style="@style/Widget.AppCompat.Button.Borderless"
+        android:layout_width="70dp"
+        android:layout_height="0dp"
+        android:paddingEnd="8dp"
+        android:paddingStart="14dp"
+        android:background="?attr/foreground_color"
+        android:scaleType="fitCenter"
+        android:contentDescription="@string/bookmark_border_icon_desc"
+        app:tint="?attr/text_second_color"
+        app:srcCompat="@drawable/ic_bookmark_border_24"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/inputHorizontalScrollView"
+        app:layout_constraintBottom_toBottomOf="@+id/inputHorizontalScrollView" />
+
     <HorizontalScrollView
         android:id="@+id/inputHorizontalScrollView"
         android:layout_width="0dp"
@@ -26,10 +42,10 @@
         android:background="?attr/foreground_color"
         android:overScrollMode="never"
         android:scrollbars="none"
+        app:layout_constraintTop_toBottomOf="@+id/menuButton"
         app:layout_constraintBottom_toTopOf="@+id/guideline1"
-        app:layout_constraintEnd_toStartOf="@+id/menuButton"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintStart_toEndOf="@+id/bookmarkButton"
+        app:layout_constraintEnd_toEndOf="parent">
 
         <EditText
             android:id="@+id/input"
@@ -106,17 +122,6 @@
                 android:textColor="?attr/text_second_color"
                 android:textIsSelectable="true"
                 android:textSize="45sp" />
-
-            <ImageButton
-                android:id="@+id/bookmarkButton"
-                style="@style/Widget.AppCompat.Button.Borderless"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:paddingHorizontal="8dp"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@string/bookmark_border_icon_desc"
-                app:tint="?attr/text_second_color"
-                app:srcCompat="@drawable/ic_bookmark_border_24" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout-sw720dp-land/activity_main.xml
+++ b/app/src/main/res/layout-sw720dp-land/activity_main.xml
@@ -120,6 +120,7 @@
         app:layout_constraintTop_toBottomOf="@+id/resultDisplayHorizontalScrollView"
         app:umanoPanelHeight="41dp"
         app:umanoShadowHeight="0dp"
+        app:umanoOverlay="true"
         tools:ignore="MissingConstraints">
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -136,7 +137,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 android:paddingHorizontal="8dp"
-                android:paddingTop="12dp"
+                android:paddingTop="48dp"
                 android:paddingBottom="0dp">
 
                 <TableRow
@@ -648,6 +649,7 @@
                     android:id="@+id/bookmarksRecyclerView"
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
+                    android:layout_marginBottom="25dp"
                     android:background="?attr/history_background_color"
                     android:visibility="gone"
                     app:layout_constraintTop_toBottomOf="@+id/historyBookmarksTabs"

--- a/app/src/main/res/layout-sw720dp-land/activity_main.xml
+++ b/app/src/main/res/layout-sw720dp-land/activity_main.xml
@@ -634,6 +634,19 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintBottom_toTopOf="@+id/sliding_layout_button"/>
 
+            <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/bookmarksRecyclerView"
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp"
+                    android:background="?attr/history_background_color"
+                    android:visibility="gone"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toTopOf="@id/sliding_layout_button"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    tools:visibility="visible"
+                    tools:listitem="@layout/history_item" />
+
             <TextView
                 android:id="@+id/no_history_text"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout-sw720dp-land/activity_main.xml
+++ b/app/src/main/res/layout-sw720dp-land/activity_main.xml
@@ -22,10 +22,10 @@
     <ImageButton
         android:id="@+id/bookmarkButton"
         style="@style/Widget.AppCompat.Button.Borderless"
-        android:layout_width="70dp"
+        android:layout_width="55dp"
         android:layout_height="0dp"
         android:paddingEnd="8dp"
-        android:paddingStart="14dp"
+        android:paddingStart="8dp"
         android:background="?attr/foreground_color"
         android:scaleType="fitCenter"
         android:contentDescription="@string/bookmark_border_icon_desc"

--- a/app/src/main/res/layout-sw720dp-land/activity_main.xml
+++ b/app/src/main/res/layout-sw720dp-land/activity_main.xml
@@ -107,6 +107,17 @@
                 android:textIsSelectable="true"
                 android:textSize="45sp" />
 
+            <ImageButton
+                android:id="@+id/bookmarkButton"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:paddingHorizontal="8dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/bookmark_border_icon_desc"
+                app:tint="?attr/text_second_color"
+                app:srcCompat="@drawable/ic_bookmark_border_24" />
+
         </LinearLayout>
 
     </HorizontalScrollView>

--- a/app/src/main/res/layout-sw720dp-land/activity_main.xml
+++ b/app/src/main/res/layout-sw720dp-land/activity_main.xml
@@ -691,6 +691,13 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"/>
 
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/list_bottom_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="history_recylcle_view,bookmarksRecyclerView,no_history_text" />
+
             <View
                 android:id="@+id/history_sliding_layout_button"
                 android:layout_width="match_parent"
@@ -698,7 +705,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/history_recylcle_view"/>
+                app:layout_constraintTop_toBottomOf="@+id/list_bottom_barrier"/>
 
 
             <View

--- a/app/src/main/res/layout-sw720dp-land/activity_main.xml
+++ b/app/src/main/res/layout-sw720dp-land/activity_main.xml
@@ -622,6 +622,16 @@
             android:layout_height="match_parent"
             tools:context=".activities.MainActivity"
             android:background="@drawable/display_background">
+
+            <com.google.android.material.tabs.TabLayout
+                    android:id="@+id/historyBookmarksTabs"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:tabIndicatorFullWidth="false"
+                    app:tabMode="fixed"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
             
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/history_recylcle_view"
@@ -629,10 +639,10 @@
                 android:layout_height="0dp"
                 android:layout_marginBottom="25dp"
                 android:background="?attr/history_background_color"
-                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/historyBookmarksTabs"
+                app:layout_constraintBottom_toTopOf="@+id/sliding_layout_button"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintBottom_toTopOf="@+id/sliding_layout_button"/>
+                app:layout_constraintEnd_toEndOf="parent"/>
 
             <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/bookmarksRecyclerView"
@@ -640,7 +650,7 @@
                     android:layout_height="0dp"
                     android:background="?attr/history_background_color"
                     android:visibility="gone"
-                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/historyBookmarksTabs"
                     app:layout_constraintBottom_toTopOf="@id/sliding_layout_button"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -658,10 +668,10 @@
                 android:gravity="center"
                 android:layout_marginBottom="32dp"
                 android:background="?attr/history_background_color"
+                app:layout_constraintTop_toBottomOf="@+id/historyBookmarksTabs"
                 app:layout_constraintBottom_toTopOf="@+id/sliding_layout_button"
-                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"/>
+                app:layout_constraintEnd_toEndOf="parent"/>
 
             <View
                 android:id="@+id/history_sliding_layout_button"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -117,6 +117,7 @@
         app:umanoPanelHeight="41dp"
         app:umanoScrollableView="@id/history_recylcle_view"
         app:umanoShadowHeight="0dp"
+        app:umanoOverlay="true"
         tools:ignore="MissingConstraints">
 
 
@@ -131,7 +132,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
                 android:paddingHorizontal="8dp"
-                android:paddingTop="12dp"
+                android:paddingTop="48dp"
                 android:paddingBottom="0dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintTop_toTopOf="parent">
@@ -644,6 +645,7 @@
                     android:id="@+id/bookmarksRecyclerView"
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
+                    android:layout_marginBottom="32dp"
                     android:background="?attr/history_background_color"
                     android:visibility="gone"
                     app:layout_constraintTop_toBottomOf="@+id/historyBookmarksTabs"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -689,12 +689,28 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"/>
 
+            <TextView
+                android:id="@+id/no_bookmarks_text"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:text="@string/no_bookmarks_available"
+                android:textSize="18sp"
+                android:textColor="?attr/text_color"
+                android:gravity="center"
+                android:layout_marginBottom="32dp"
+                android:background="?attr/history_background_color"
+                android:visibility="gone"
+                app:layout_constraintTop_toBottomOf="@+id/historyBookmarksTabs"
+                app:layout_constraintBottom_toTopOf="@+id/sliding_layout_button"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
             <androidx.constraintlayout.widget.Barrier
                 android:id="@+id/list_bottom_barrier"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 app:barrierDirection="bottom"
-                app:constraint_referenced_ids="history_recylcle_view,bookmarksRecyclerView,no_history_text" />
+                app:constraint_referenced_ids="history_recylcle_view,bookmarksRecyclerView,no_history_text,no_bookmarks_text" />
 
             <View
                 android:id="@+id/history_sliding_layout_button"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -103,6 +103,17 @@
                 android:textIsSelectable="true"
                 android:textSize="35sp" />
 
+            <ImageButton
+                android:id="@+id/bookmarkButton"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:paddingHorizontal="8dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/bookmark_border_icon_desc"
+                app:tint="?attr/text_second_color"
+                app:srcCompat="@drawable/ic_bookmark_border_24" />
+
         </LinearLayout>
 
     </HorizontalScrollView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,10 +21,10 @@
     <ImageButton
         android:id="@+id/bookmarkButton"
         style="@style/Widget.AppCompat.Button.Borderless"
-        android:layout_width="70dp"
+        android:layout_width="55dp"
         android:layout_height="0dp"
         android:paddingEnd="8dp"
-        android:paddingStart="14dp"
+        android:paddingStart="8dp"
         android:background="?attr/foreground_color"
         android:scaleType="fitCenter"
         android:contentDescription="@string/bookmark_border_icon_desc"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -18,15 +18,33 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <ImageButton
+        android:id="@+id/bookmarkButton"
+        style="@style/Widget.AppCompat.Button.Borderless"
+        android:layout_width="70dp"
+        android:layout_height="0dp"
+        android:paddingEnd="8dp"
+        android:paddingStart="14dp"
+        android:background="?attr/foreground_color"
+        android:scaleType="fitCenter"
+        android:contentDescription="@string/bookmark_border_icon_desc"
+        app:tint="?attr/text_second_color"
+        app:srcCompat="@drawable/ic_bookmark_border_24"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/inputHorizontalScrollView"
+        app:layout_constraintBottom_toBottomOf="@+id/inputHorizontalScrollView" />
+
     <HorizontalScrollView
         android:id="@+id/inputHorizontalScrollView"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="0dp"
         android:background="?attr/foreground_color"
         android:overScrollMode="never"
         android:scrollbars="none"
+        app:layout_constraintTop_toBottomOf="@+id/menuButton"
         app:layout_constraintBottom_toTopOf="@+id/guideline1"
-        app:layout_constraintTop_toBottomOf="@+id/menuButton">
+        app:layout_constraintStart_toEndOf="@+id/bookmarkButton"
+        app:layout_constraintEnd_toEndOf="parent">
 
         <EditText
             android:id="@+id/input"
@@ -102,17 +120,6 @@
                 android:textColor="?attr/text_second_color"
                 android:textIsSelectable="true"
                 android:textSize="35sp" />
-
-            <ImageButton
-                android:id="@+id/bookmarkButton"
-                style="@style/Widget.AppCompat.Button.Borderless"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:paddingHorizontal="8dp"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@string/bookmark_border_icon_desc"
-                app:tint="?attr/text_second_color"
-                app:srcCompat="@drawable/ic_bookmark_border_24" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -631,6 +631,19 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
+            <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/bookmarksRecyclerView"
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp"
+                    android:background="?attr/history_background_color"
+                    android:visibility="gone"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toTopOf="@id/sliding_layout_button"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    tools:visibility="visible"
+                    tools:listitem="@layout/history_item" />
+
             <TextView
                 android:id="@+id/no_history_text"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -619,6 +619,15 @@
             android:background="@drawable/display_background"
             tools:context=".activities.MainActivity">
 
+            <com.google.android.material.tabs.TabLayout
+                    android:id="@+id/historyBookmarksTabs"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:tabIndicatorFullWidth="false"
+                    app:tabMode="fixed"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/history_recylcle_view"
@@ -626,10 +635,10 @@
                 android:layout_height="0dp"
                 android:layout_marginBottom="32dp"
                 android:background="?attr/history_background_color"
+                app:layout_constraintTop_toBottomOf="@+id/historyBookmarksTabs"
                 app:layout_constraintBottom_toTopOf="@+id/sliding_layout_button"
-                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintEnd_toEndOf="parent" />
 
             <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/bookmarksRecyclerView"
@@ -637,7 +646,7 @@
                     android:layout_height="0dp"
                     android:background="?attr/history_background_color"
                     android:visibility="gone"
-                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/historyBookmarksTabs"
                     app:layout_constraintBottom_toTopOf="@id/sliding_layout_button"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -655,10 +664,10 @@
                 android:gravity="center"
                 android:layout_marginBottom="32dp"
                 android:background="?attr/history_background_color"
+                app:layout_constraintTop_toBottomOf="@+id/historyBookmarksTabs"
                 app:layout_constraintBottom_toTopOf="@+id/sliding_layout_button"
-                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"/>
+                app:layout_constraintEnd_toEndOf="parent"/>
 
             <View
                 android:id="@+id/history_sliding_layout_button"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -689,6 +689,13 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"/>
 
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/list_bottom_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="history_recylcle_view,bookmarksRecyclerView,no_history_text" />
+
             <View
                 android:id="@+id/history_sliding_layout_button"
                 android:layout_width="match_parent"
@@ -696,7 +703,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/history_recylcle_view"/>
+                app:layout_constraintTop_toBottomOf="@+id/list_bottom_barrier"/>
 
             <View
                 android:id="@+id/sliding_layout_button"

--- a/app/src/main/res/menu/app_menu.xml
+++ b/app/src/main/res/menu/app_menu.xml
@@ -6,6 +6,11 @@
         android:onClick="clearHistory" />
 
     <item
+        android:id="@+id/app_menu_clear_bookmarks_button"
+        android:title="@string/menu_clear_bookmarks"
+        android:onClick="clearBookmarks" />
+
+    <item
         android:id="@+id/app_menu_settings_button"
         android:title="@string/menu_settings"
         android:onClick="openSettings" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -178,4 +178,5 @@
     <!-- Bookmarks -->
     <string name="nothing_to_bookmark">Nothing to bookmark</string>
     <string name="bookmarked">Bookmarked</string>
+    <string name="bookmarks_tab_title">Bookmarks</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,4 +174,8 @@
     <string name="no_history_available">No History Available</string>
     <string name="show_on_lock_screen">Show on Lock Screen</string>
     <string name="keep_the_calculator_visible_on_your_lock_screen_for_quick_and_easy_access_disable_to_hide_it_when_your_screen_is_locked">Keep the calculator visible on your lock screen for quick and easy access. Disable to hide it when your screen is locked.</string>
+
+    <!-- Bookmarks -->
+    <string name="nothing_to_bookmark">Nothing to bookmark</string>
+    <string name="bookmarked">Bookmarked</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,4 +180,5 @@
     <string name="bookmarked">Bookmarked</string>
     <string name="bookmarks_tab_title">Bookmarks</string>
     <string name="history_tab_title">History</string>
+    <string name="bookmark_border_icon_desc">Bookmark</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,6 +180,7 @@
     <string name="bookmarks_tab_title">Bookmarks</string>
     <string name="history_tab_title">History</string>
     <string name="bookmark_border_icon_desc">Bookmark</string>
+    <string name="no_bookmarks_available">No Bookmarks Available</string>
 
     <!-- Clear bookmarks menu and alert modal -->
     <string name="menu_clear_bookmarks">Clear bookmarks</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,8 +177,14 @@
 
     <!-- Bookmarks and History tabs -->
     <string name="nothing_to_bookmark">Nothing to bookmark</string>
-    <string name="bookmarked">Bookmarked</string>
     <string name="bookmarks_tab_title">Bookmarks</string>
     <string name="history_tab_title">History</string>
     <string name="bookmark_border_icon_desc">Bookmark</string>
+
+    <!-- Clear bookmarks menu and alert modal -->
+    <string name="menu_clear_bookmarks">Clear bookmarks</string>
+    <string name="confirm_clear_bookmarks_title">Delete all saved bookmarks ?</string>
+    <string name="bookmarks_cleared">Bookmarks cleared</string>
+    <string name="confirm_clear_bookmarks_button">Yes</string>
+    <string name="cancel_clear_bookmarks_button">No</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,8 +175,9 @@
     <string name="show_on_lock_screen">Show on Lock Screen</string>
     <string name="keep_the_calculator_visible_on_your_lock_screen_for_quick_and_easy_access_disable_to_hide_it_when_your_screen_is_locked">Keep the calculator visible on your lock screen for quick and easy access. Disable to hide it when your screen is locked.</string>
 
-    <!-- Bookmarks -->
+    <!-- Bookmarks and History tabs -->
     <string name="nothing_to_bookmark">Nothing to bookmark</string>
     <string name="bookmarked">Bookmarked</string>
     <string name="bookmarks_tab_title">Bookmarks</string>
+    <string name="history_tab_title">History</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,7 @@
     <string name="history_tab_title">History</string>
     <string name="bookmark_border_icon_desc">Bookmark</string>
     <string name="no_bookmarks_available">No Bookmarks Available</string>
+    <string name="bookmarked">Added to bookmarks</string>
 
     <!-- Clear bookmarks menu and alert modal -->
     <string name="menu_clear_bookmarks">Clear bookmarks</string>


### PR DESCRIPTION
### Added Functionality
1. History and Bookmarks are separate tabs with separate storage in the sliding panel. Bookmarks are implemented with the same style, structure, separators and functionality (swipe to delete, click to copy) as already existing history.
2. "No Bookmarks Available" text when bookmarks tab has no saved bookmarks similar as in history.
3. Bookmark icon on the left side of the calculation line used to toggle (add/remove) the calculation/result from bookmarks. The bookmark icon fills to signal to the user that this calculation has been bookmarked.
4. Clear bookmarks button in the menu to delete all saved bookmarks. After clicking the "Clear bookmarks" a modal will be shown and user must confirm this deletion to avoid potential missclicks.

Here is a short PDF file containing the aforementioned functionality with added screenshots from the app for better demonstration of the added functionality:
[OpenCalc_384_bookmarks.pdf](https://github.com/user-attachments/files/23167035/OpenCalc_384_bookmarks.pdf)

I tried to implement it correctly across all layouts and with minimal changes to the already existing implementations, but if you find any bugs, weird behaviour or wonky/broken UI feel free to tell me.

