### PR TITLE
Fix gamma function crash for large input

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/calculator/Calculator.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/calculator/Calculator.kt
@@ -76,7 +76,7 @@ class Calculator(
         val firstPart = sqrtTwoPi * t.pow(z + 0.5) * exp(-t)
         val result = firstPart * a
 
-        if (!result.isFinite()) {
+        if (result.isInfinite()) {
             is_infinity = true
             return BigDecimal.ZERO
         }

--- a/app/src/main/java/com/darkempire78/opencalculator/calculator/Calculator.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/calculator/Calculator.kt
@@ -76,6 +76,10 @@ class Calculator(
         val firstPart = sqrtTwoPi * t.pow(z + 0.5) * exp(-t)
         val result = firstPart * a
 
+        if (!result.isFinite()) {
+            is_infinity = true
+            return BigDecimal.ZERO
+        }
         return BigDecimal(result, MathContext.DECIMAL64)
     }
 

--- a/app/src/main/java/com/darkempire78/opencalculator/calculator/Calculator.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/calculator/Calculator.kt
@@ -76,7 +76,7 @@ class Calculator(
         val firstPart = sqrtTwoPi * t.pow(z + 0.5) * exp(-t)
         val result = firstPart * a
 
-        if (result.isInfinite()) {
+        if (!result.isFinite()) {
             is_infinity = true
             return BigDecimal.ZERO
         }

--- a/app/src/test/java/com/darkempire78/opencalculator/ExpressionUnitTest.kt
+++ b/app/src/test/java/com/darkempire78/opencalculator/ExpressionUnitTest.kt
@@ -73,7 +73,7 @@ class ExpressionUnitTest {
         Samsung Calculator has a result of 22.76976 here and Google Calculator yields 16.732.
         OpenCalc yields 18.75176. 4Investigating the correct answer.
          We typically would not do something so ambiguous. Are we adding percentages or adding a
-         a percentage of the previous number? An answer of 7.21 is also possible. How far down
+         percentage of the previous number? An answer of 7.21 is also possible. How far down
          this rabbit hole do we want to go? Everyday calculations should be correct now.
          */
         result = calculate("164%+(265-20%)%+345%", isDegreeModeActivated = false).toDouble()
@@ -190,6 +190,9 @@ class ExpressionUnitTest {
 
         result = calculate("(3!)!/(3!)!", false).toDouble()
         assertEquals(1.0, result, 0.0)
+
+        result  =  calculate("(21.3*12.5)!",false).toDouble()
+        assertEquals(0.0, result, 0.0)
     }
 
     @Test


### PR DESCRIPTION
As described in [#600](https://github.com/clementwzk/OpenCalc/issues/600), the app crashes when the Gamma function is evaluated with very large inputs.

This happens because a NumberFormatException is thrown when attempting to create a BigDecimal from an infinite (Infinity) result.

To prevent this, the value is now checked for finiteness before converting it to BigDecimal, ensuring that overflow cases are handled safely instead of causing a crash.