### PR TITLE
Feature #623 Factorial directly after function

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/calculator/parser/Expression.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/calculator/parser/Expression.kt
@@ -329,8 +329,8 @@ class Expression {
                     if (cleanCalculation[i - 1] == ')') {
                         // Replace the "!" by ")"
                         cleanCalculation = cleanCalculation.substring(0, i) + ')' + cleanCalculation.substring(i + 1)
-
-                        for (j in i downTo 1) {
+                        var j = i
+                        while(j>0){
                             if (cleanCalculation[j - 1] == ')') parenthesisOpened += 1
                             else if (cleanCalculation[j - 1] == '(') {
                                 parenthesisOpened -= 1
@@ -338,15 +338,15 @@ class Expression {
                                 // If there are no open parentheses, add an F in front of the 1st parenthesis
                                 if (parenthesisOpened == 0) {
                                     // Check if there is a function name before the parenthesis
-                                    var k = j - 2
-                                    while (k >= 0 && cleanCalculation[k].isLetter()) k--
+                                    while (j-2 >= 0 && cleanCalculation[j-2].isLetter()) j--
 
-                                    cleanCalculation = cleanCalculation.addCharAtIndex('(', k+1)
-                                    cleanCalculation = cleanCalculation.addCharAtIndex('F', k+1)
+                                    cleanCalculation = cleanCalculation.addCharAtIndex('(', j-1)
+                                    cleanCalculation = cleanCalculation.addCharAtIndex('F', j-1)
                                     i += 2
                                     break
                                 }
                             }
+                            j--
                         }
                     } else {
                         // If the previous character is not a parenthesis, add one

--- a/app/src/main/java/com/darkempire78/opencalculator/calculator/parser/Expression.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/calculator/parser/Expression.kt
@@ -326,30 +326,27 @@ class Expression {
                 // If the current character is "!"
                 if (cleanCalculation[i] == '!') {
                     // If the previous character is a parenthesis
-                    if (cleanCalculation[i-1] == ')') {
-                        // Remove the "!"
-                        cleanCalculation = cleanCalculation.substring(0, i) + cleanCalculation.substring(i+1)
+                    if (cleanCalculation[i - 1] == ')') {
+                        // Replace the "!" by ")"
+                        cleanCalculation = cleanCalculation.substring(0, i) + ')' + cleanCalculation.substring(i + 1)
 
-                        var j = i
-                        while (j > 0) {
-                            if (cleanCalculation[j-1] in "*/+^" && parenthesisOpened == 0) {
-                                break
-                            }
-                            if (cleanCalculation[j-1] == ')') parenthesisOpened += 1
-                            // If the previous character isn't a parenthesis
-                            if (cleanCalculation[j-1] != ')') {
-                                // Count open parentheses
-                                if (cleanCalculation[j-1] == '(') parenthesisOpened -= 1
+                        for (j in i downTo 1) {
+                            if (cleanCalculation[j - 1] == ')') parenthesisOpened += 1
+                            else if (cleanCalculation[j - 1] == '(') {
+                                parenthesisOpened -= 1
 
                                 // If there are no open parentheses, add an F in front of the 1st parenthesis
                                 if (parenthesisOpened == 0) {
-                                    cleanCalculation = cleanCalculation.addCharAtIndex('F', j-1)
+                                    // Check if there is a function name before the parenthesis
+                                    var k = j - 2
+                                    while (k >= 0 && cleanCalculation[k].isLetter()) k--
+
+                                    cleanCalculation = cleanCalculation.addCharAtIndex('(', k+1)
+                                    cleanCalculation = cleanCalculation.addCharAtIndex('F', k+1)
+                                    i += 2
                                     break
                                 }
                             }
-
-                            // Decrement i on each run
-                            j--
                         }
                     } else {
                         // If the previous character is not a parenthesis, add one

--- a/app/src/test/java/com/darkempire78/opencalculator/ExpressionUnitTest.kt
+++ b/app/src/test/java/com/darkempire78/opencalculator/ExpressionUnitTest.kt
@@ -193,6 +193,21 @@ class ExpressionUnitTest {
     }
 
     @Test
+    fun factorial_with_nested_function_isCorrect(){
+        var result = calculate("log₂(8)!", false).toDouble()
+        assertEquals(6.0, result, 0.0)
+
+        result = calculate("2sin(1.5!)!", false).toDouble()
+        assertEquals(1.976160058508777, result, 0.0)
+
+        result = calculate("etan(1.2!)!", false).toDouble()
+        assertEquals(5.306218585566812, result, 0.0)
+
+        result = calculate("e(1.2!)!", false).toDouble()
+        assertEquals(2.8471358887880265, result, 0.0)
+    }
+
+    @Test
     fun factorial_percent_isCorrect() {
         var result = calculate("5!%", false).toDouble()
         assertEquals(1.2, result, 0.0)


### PR DESCRIPTION
As described in [#623](https://github.com/clementwzk/OpenCalc/issues/623) a factorial can now be placed directly after a function without the need of extra parenthesis like (sin(2))!.

This is archived by not adding the "F" directly in front of the last "(" but checking if a sequence of letters (the function name) is before the "(". If yes, then "F(" is inserted in front of the function. 

All in all this change should behave like this for functions nested inside factorials:

func-name(expression)! -> F(func-name(expression)) 

